### PR TITLE
q2axis function correction

### DIFF
--- a/fortran/Quaternions.f90
+++ b/fortran/Quaternions.f90
@@ -371,7 +371,7 @@ CONTAINS
     double precision :: u(3), normer
     TYPE(qtrn), INTENT(IN) :: q
 
-    normer = 1.d0/sin(q2angle(q))
+    normer = 1.d0/sin(q2angle(q)/2.d0)
     u(1) = q%x*normer
     u(2) = q%y*normer
     u(3) = q%z*normer


### PR DESCRIPTION
I've found an error when getting the sine of the semi-angle of rotation in order to calculate the axis of rotation. I propose this simply solution, to divide the angle between 2.
